### PR TITLE
Add functionality to allow images as icons

### DIFF
--- a/dist/emotion-ratings.js
+++ b/dist/emotion-ratings.js
@@ -29,6 +29,7 @@
         ratingCode: 5,
         disabled: false,
         useCustomEmotions: false,
+        transformImages: false,
     };
     //the collection of emotions to show on the ratings
     var emotionsArray = {
@@ -117,6 +118,10 @@
             }else{
                 this.appendInput();
             }
+
+            if(this.settings.transformImages){
+                this.transformImgsToSVG();
+            }
         },
         clearEmotion: function(content) {
             if(!this.settings.disabled){
@@ -131,7 +136,7 @@
                       $(this).css("opacity", 0.3);
                       $(this).html(bgEmotion);
                 });
-            }       
+            }
         },
         showEmotion: function(count) {
             this.clearEmotion(this.settings.bgEmotion);
@@ -147,10 +152,14 @@
                 this.elementContainer.find("."+this.styleCode+"").eq(i).css("opacity", 1);
                 this.elementContainer.find("."+this.styleCode+"").eq(i).html(emotion);
             }
+            if(this.settings.transformImages){
+                this.transformImgsToSVG();
+            }
+            
         },
         manageHover: function() {
             var self = this;
-            if(!self.settings.disabled){
+            if(!self.settings.disabled && !self.settings.transformImages){
                 
                 this.elementContainer.on({
                     mouseenter: function() {
@@ -212,6 +221,31 @@
             var _input = this.elementContainer.find("input."+this.code+"");
 
             _input.val(count);
+        },
+        transformImgsToSVG: function(){
+            // Based in https://bit.ly/2S5Onvx
+            this.elementContainer.find('img[src$=".svg"]').each(function(){
+                var $img = jQuery(this);
+                var imgURL = $img.attr('src');
+                var attributes = $img.prop("attributes");
+
+                $.get(imgURL, function(data) {
+                  // Get the SVG tag, ignore the rest
+                  var $svg = jQuery(data).find('svg');
+
+                  // Remove any invalid XML tags
+                  $svg = $svg.removeAttr('xmlns:a');
+
+                  // Loop through IMG attributes and apply on SVG
+                  $.each(attributes, function() {
+                    $svg.attr(this.name, this.value);
+                  });
+
+                  // Replace IMG with SVG
+                  $img.replaceWith($svg);
+                }, 'xml');
+
+            });
         }
     });
 

--- a/dist/emotion-ratings.js
+++ b/dist/emotion-ratings.js
@@ -21,15 +21,14 @@
     // Default options for the plugin as a simple object
     var defaults = {
         bgEmotion: "happy",
-        emotionsCollection: ['angry','disappointed','meh', 'happy', 'inlove'],
         count: 5,
         color: "#d0a658;",
         emotionSize: 30,
         inputName: "ratings[]",
         emotionOnUpdate: null,
         ratingCode: 5,
-        disabled: false
-
+        disabled: false,
+        useCustomEmotions: false,
     };
     //the collection of emotions to show on the ratings
     var emotionsArray = {
@@ -49,12 +48,11 @@
         like: "&#x1F44D;",
         dislike: "&#x1F44E;"
       };
-   // var clicked = false;//[false,false,false];
+
     // Plugin constructor
     // This is the boilerplate to set up the plugin to keep our actual logic in one place
     function Plugin(element, options) {
         this.element = element;
-
         // Merge the options given by the user with the defaults
         this.settings = $.extend( {}, defaults, options );
         // Attach data to the element
@@ -98,9 +96,14 @@
             $element.append("<style>" + styles + "</style>");
         },
         renderEmotion: function () {
-           
             var count = this.settings.count;
+            var useCustomEmotions = this.settings.useCustomEmotions;
             var bgEmotion = emotionsArray[this.settings.bgEmotion];
+
+            if(useCustomEmotions){
+              bgEmotion = "<img src='"+this.settings.bgEmotion+"' class='custom-"+this.styleCode+"'>";
+            }
+
             var container = "<div class='"+this.containerCode+"'>";
             var emotionDiv;
             for (var i = 1; i <= count; i++) {
@@ -117,17 +120,29 @@
         },
         clearEmotion: function(content) {
             if(!this.settings.disabled){
+                var useCustomEmotions = this.settings.useCustomEmotions;
+                var bgEmotion = emotionsArray[content];
+
+                if(useCustomEmotions){
+                  bgEmotion = "<img src='"+this.settings.bgEmotion+"' class='custom-"+this.styleCode+"'>";
+                }
+
                 this.elementContainer.find("."+this.styleCode+"").each( function() {
-                    $(this).css("opacity", 0.3);
-                    var bgEmotion = emotionsArray[content];
-                    $(this).html(bgEmotion);
+                      $(this).css("opacity", 0.3);
+                      $(this).html(bgEmotion);
                 });
-            }
-            
+            }       
         },
         showEmotion: function(count) {
             this.clearEmotion(this.settings.bgEmotion);
-            var emotion = getEmotion(this.settings.emotions,count);
+            var useCustomEmotions = this.settings.useCustomEmotions;
+            var emotion = getEmotion(this.settings.emotions,count,useCustomEmotions);
+
+            if(useCustomEmotions){
+              emotion = this.settings.emotions[emotion];
+              emotion = "<img src='"+emotion+"' class='custom-"+this.styleCode+"'>";
+            }
+
             for (var i = 0; i < count; i++) {               
                 this.elementContainer.find("."+this.styleCode+"").eq(i).css("opacity", 1);
                 this.elementContainer.find("."+this.styleCode+"").eq(i).html(emotion);
@@ -210,12 +225,17 @@
         });
     };
 
-    var getEmotion = function(_emotions,count) {
+    var getEmotion = function(_emotions,count, onlyIndex = false) {
         var emotion;
-        if (_emotions.length == 1) {
-            emotion = emotionsArray[_emotions[0]];
+        var emotionsLength = _emotions.length;
+        if (emotionsLength == 1) {
+            emotion = onlyIndex ? 0 : emotionsArray[_emotions[0]];
         }else{
-            emotion = emotionsArray[_emotions[count-1]];
+          var emotionIndex = (count-1);
+          emotion = onlyIndex 
+                  ? (emotionIndex > (emotionsLength-1)) 
+                      ? (emotionsLength-1) : emotionIndex 
+                  : emotionsArray[_emotions[count-1]];
         }
         return emotion;
     }


### PR DESCRIPTION
# what does this PR?

**Adding functionality to allow images as icons**

Two options are added:
- `useCustomEmotions`: Boolean. This option verifies if you want to use images as icons.
- `transformImages`: Boolean. This option verifies if you want to process the images. For example; an _svg_ type image when it is added in an _img_ tag, you can not access certain functionalities such as changing the color and border, because it is not in the correct _svg_ tag, and for that reason you have to convert the _img_ tag into a _svg_ type. This process can take processing time and unnecessary in some cases, for this reason it is asked if you want to transform the images and get more features.

_**Short explanation of code**_

Following the original logic, you need by default an icon to display with less opacity, and an array with the icons to show in each position, in the original idea you pass the name of the icon to be displayed, but in the new functionality you have to specify the path of the image you want to show. For example in _bgEmotion_ option; `bgEmotion: 'icons/icon.svg'` and in _emotions_ array `emotions: ['icons/icon1.svg', 'icons/icon2.svg']`

All the original operation is implemented in the new functionality, except that the _hover_ event is disabled when `useCustomEmotions: true` and `transformImages: true`, because it causes the images to be transformed a large number of times, causing almost to fall in a cycle .

# Demo

[![Edit emojis](https://codesandbox.io/static/img/play-codesandbox.svg)](https://codesandbox.io/s/4wl1k2lj3w)

***
_Great idea of the plugin, it was not complicated to add the new functionality due to the logic you raised. I learned new things with this contribution. Good job :)._
